### PR TITLE
Corrected profile name setup

### DIFF
--- a/Systems.org
+++ b/Systems.org
@@ -602,9 +602,9 @@ fi
 for profile in $profiles; do
   # Remove the path and file extension, if any
   profileName=$(basename $profile)
-  profileName="${profile%.*}"
+  profileName="${profileName%.*}"
   profilePath="$GUIX_EXTRA_PROFILES/$profileName"
-  manifestPath=$HOME/.config/guix/manifests/$profile.scm
+  manifestPath=$HOME/.config/guix/manifests/$profileName.scm
 
   if [ -f $manifestPath ]; then
     echo


### PR DESCRIPTION
Hi David,
I noted a couple of small errors in .bin/activate-profiles. It worked for adding one profile, but failed when adding all the profiles in the manifest directory. 

Best regards,
Paul