### PR TITLE
systems: Remove -E from sudo call

### DIFF
--- a/Systems.org
+++ b/Systems.org
@@ -111,7 +111,7 @@ Any configuration that derives from =base-operating-system= must invoke =guix sy
 
 #+begin_src sh
 
-sudo -E guix system -L ~/.dotfiles/.config/guix/systems reconfigure ~/.dotfiles/.config/guix/systems/davinci.scm
+sudo guix system -L ~/.dotfiles/.config/guix/systems reconfigure ~/.dotfiles/.config/guix/systems/davinci.scm
 
 #+end_src
 


### PR DESCRIPTION
Fixes #11 ;)

The `guix` command in `PATH` is updated after running `guix pull`, so `sudo guix` should get the right generation if you've run `guix pull` beforehand. The `-E` flag is unnecessary and can cause trouble.